### PR TITLE
Basic nonportable functions/includes for Windows

### DIFF
--- a/libjl777/plugins/nonportable/win/nonportable.h
+++ b/libjl777/plugins/nonportable/win/nonportable.h
@@ -1,0 +1,30 @@
+#ifndef NONPORTABLE_WIN_H
+#define NONPORTABLE_WIN_H
+
+//Includes
+#include <inttypes.h>
+#include <windows.h>
+#include <winsock2.h>
+#include <in6addr.h>
+#include <io.h>
+#include <errno.h>
+#include <fcntl.h> /*  _O_BINARY */
+
+//Type Definitions
+
+
+
+//Data Structures
+struct iovec
+{
+ void	*iov_base; /* Base address of a memory region for input or output */
+ size_t	iov_len; /* The size of the memory pointed to by iov_base */
+};
+
+//Functions
+#define pipe(phandles)	_pipe (phandles, 4096, _O_BINARY)
+
+
+
+
+#endif

--- a/libjl777/plugins/nonportable/win/sys/mman.h
+++ b/libjl777/plugins/nonportable/win/sys/mman.h
@@ -1,0 +1,55 @@
+/*
+ * sys/mman.h
+ * mman-win32
+ */
+
+#ifndef _SYS_MMAN_H_
+#define _SYS_MMAN_H_
+
+#ifndef _WIN32_WINNT		// Allow use of features specific to Windows XP or later.                   
+#define _WIN32_WINNT 0x0501	// Change this to the appropriate value to target other versions of Windows.
+#endif						
+
+/* All the headers include this file. */
+#ifndef _MSC_VER
+#include <_mingw.h>
+#endif
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PROT_NONE       0
+#define PROT_READ       1
+#define PROT_WRITE      2
+#define PROT_EXEC       4
+
+#define MAP_FILE        0
+#define MAP_SHARED      1
+#define MAP_PRIVATE     2
+#define MAP_TYPE        0xf
+#define MAP_FIXED       0x10
+#define MAP_ANONYMOUS   0x20
+#define MAP_ANON        MAP_ANONYMOUS
+
+#define MAP_FAILED      ((void *)-1)
+
+/* Flags for msync. */
+#define MS_ASYNC        1
+#define MS_SYNC         2
+#define MS_INVALIDATE   4
+
+void*   mmap(void *addr, size_t len, int prot, int flags, int fildes, off_t off);
+int     munmap(void *addr, size_t len);
+int     mprotect(void *addr, size_t len, int prot);
+int     msync(void *addr, size_t len, int flags);
+int     mlock(const void *addr, size_t len);
+int     munlock(const void *addr, size_t len);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /*  _SYS_MMAN_H_ */


### PR DESCRIPTION
This pull request contains 2 files.

For nonportable, we can route the include path in Makefile based on OS variable. (Probably passed into make as a cmd arg)

If OS=win, we can add -I plugins/nonportable/win to the include path, same for Linux, etc.

The file in sys is mman.h. This way we can still #include <sys/mman.h>, regardless of OS.

The second file is nonportable.h, which we should be including in files which include non portable headers, such as netdb.h, or contain functions which need to be ported, such as pipe().